### PR TITLE
Fix replication provider and server_id

### DIFF
--- a/providers/replication.rb
+++ b/providers/replication.rb
@@ -75,8 +75,11 @@ action :remove do
 end
 
 action :start do
-  command_master_connection = ' \'' + new_resource.name + \
-    '\'' unless new_resource.name == 'default'
+  if new_resource.name == 'default'
+    command_master_connection = ''
+  else
+    command_master_connection = ' \'' + new_resource.name + '\''
+  end
   execute 'start_replication_from_master_' + new_resource.name do
     # Add sensitive true when foodcritic #233 fixed
     command '/bin/echo "START SLAVE' + command_master_connection + ';' \

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -94,7 +94,7 @@ if node['mariadb']['replication']['log_bin']
 end
 
 unless node['mariadb']['replication']['server_id'].empty?
-  replication_opts['server-id'] = node['mariadb']['replication']['server_id']
+  replication_opts['server_id'] = node['mariadb']['replication']['server_id']
 end
 node['mariadb']['replication']['options'].each do |key, value|
   replication_opts[key] = value


### PR DESCRIPTION
START SLAVE fails due to nil string when replication resource name is default.
Fix server_id key in replication config.
